### PR TITLE
Purge webhook records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
+### Added
+- `craft-shopify/webhook/purge` command to purge webhooks older than X days
+- `CraftShopify::$plugin->webhook->purgeResponses()` Method to purge webhook records via queue
+- Utility for purging webhook records
+
 ## Updated
 - Now requires Craft 3.2 or higher
 

--- a/src/console/controllers/WebhookController.php
+++ b/src/console/controllers/WebhookController.php
@@ -25,15 +25,36 @@ class WebhookController extends Controller
     public $defaultAction = 'purge';
 
     /**
+     * Length in days to purge before
+     *
+     * @var int
+     */
+    public $olderThan = 30;
+
+    /**
+     * @param string $actionID
+     * @return array
+     */
+    public function options($actionID): array
+    {
+        $options = parent::options($actionID);
+        $options[] = 'olderThan';
+
+        return $options;
+    }
+
+    /**
      * Purge webhook records
      */
     public function actionPurge()
     {
-        $olderThan = $this->prompt('Older than how many days?', [
-            'default' => 30
-        ]);
+        if (!$this->olderThan) {
+            $this->olderThan = $this->prompt('Older than how many days?', [
+                'default' => 30
+            ]);
+        }
 
-        CraftShopify::$plugin->webhook->purgeResponses($olderThan);
+        CraftShopify::$plugin->webhook->purgeResponses($this->olderThan);
         return ExitCode::OK;
     }
 

--- a/src/console/controllers/WebhookController.php
+++ b/src/console/controllers/WebhookController.php
@@ -48,12 +48,6 @@ class WebhookController extends Controller
      */
     public function actionPurge()
     {
-        if (!$this->olderThan) {
-            $this->olderThan = $this->prompt('Older than how many days?', [
-                'default' => 30
-            ]);
-        }
-
         CraftShopify::$plugin->webhook->purgeResponses($this->olderThan);
         return ExitCode::OK;
     }

--- a/src/console/controllers/WebhookController.php
+++ b/src/console/controllers/WebhookController.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * slumberkins-cms module for Craft CMS 3.x
+ *
+ * @link      https://onedesigncompany.com
+ * @copyright Copyright (c) 2021 One Design Company
+ */
+
+namespace onedesign\craftshopify\console\controllers;
+
+use craft\console\Controller;
+use onedesign\craftshopify\CraftShopify;
+use yii\console\ExitCode;
+
+
+/**
+ * Allows you to manage webhooks
+ *
+ * @author    One Design Company
+ * @package   slumberkins-cms
+ * @since     1.0.0
+ */
+class WebhookController extends Controller
+{
+    public $defaultAction = 'purge';
+
+    /**
+     * Purge webhook records
+     */
+    public function actionPurge()
+    {
+        $olderThan = $this->prompt('Older than how many days?', [
+            'default' => 30
+        ]);
+
+        CraftShopify::$plugin->webhook->purgeResponses($olderThan);
+        return ExitCode::OK;
+    }
+
+}

--- a/src/controllers/WebhookController.php
+++ b/src/controllers/WebhookController.php
@@ -15,11 +15,11 @@ use craft\errors\ElementNotFoundException;
 use craft\helpers\Json;
 use craft\web\Controller;
 use onedesign\craftshopify\CraftShopify;
-use onedesign\craftshopify\elements\Product;
 use onedesign\craftshopify\models\WebhookResponse;
 use Throwable;
 use yii\base\Action;
 use yii\base\Exception;
+use yii\db\StaleObjectException;
 use yii\web\BadRequestHttpException;
 use yii\web\ForbiddenHttpException;
 use yii\web\Response;
@@ -130,4 +130,26 @@ class WebhookController extends Controller
         CraftShopify::$plugin->webhook->saveResponse($response);
         return $this->asRaw('Webhook received');
     }
+
+    /**
+     * Purge old webhook records
+     *
+     * @return Response
+     * @throws BadRequestHttpException
+     * @throws ForbiddenHttpException
+     * @throws Throwable
+     * @throws StaleObjectException
+     */
+    public function actionPurge(): Response
+    {
+        $this->requirePostRequest();
+        $this->requireAdmin(false);
+        $olderThan = (int)$this->request->getParam('olderThan');
+
+        CraftShopify::$plugin->webhook->purgeResponses($olderThan);
+
+        $this->setSuccessFlash("Purging Webhook records older than $olderThan days.");
+        return $this->redirectToPostedUrl();
+    }
 }
+

--- a/src/jobs/PurgeWebhookResponses.php
+++ b/src/jobs/PurgeWebhookResponses.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * slumberkins-cms module for Craft CMS 3.x
+ *
+ * @link      https://onedesigncompany.com
+ * @copyright Copyright (c) 2021 One Design Company
+ */
+
+
+namespace onedesign\craftshopify\jobs;
+
+
+use Craft;
+use craft\queue\BaseJob;
+use DateTime;
+use Exception;
+use onedesign\craftshopify\records\WebhookResponseRecord;
+
+/**
+ * @author    One Design Company
+ * @package   slumberkins-cms
+ * @since     1.0.0
+ */
+class PurgeWebhookResponses extends BaseJob
+{
+
+    /**
+     * @var int Purge records older than X days
+     */
+    public $olderThan;
+
+    /**
+     * @inheritDoc
+     * @param $queue
+     * @throws \Throwable
+     * @throws \yii\db\StaleObjectException
+     */
+    public function execute($queue)
+    {
+        if (!$this->olderThan) {
+            throw new Exception('olderThan is required');
+        }
+
+        $now = new DateTime();
+        $lowerBound = $now->modify('-' . $this->olderThan . ' day');
+        $lowerBoundString = $lowerBound->format('Y-m-d');
+
+        $query = WebhookResponseRecord::find()
+            ->where(['<', 'dateCreated', $lowerBoundString]);
+
+        $totalRecords = $query->count();
+
+        /** @var WebhookResponseRecord $record */
+        foreach ($query->each() as $i => $record) {
+            $this->setProgress(
+                $queue,
+                $i / $totalRecords,
+                Craft::t('craft-shopify', '{step, number} of {total, number}', [
+                    'step' => $i + 1,
+                    'total' => $totalRecords
+                ])
+            );
+
+            $record->delete();
+        }
+    }
+
+    protected function defaultDescription(): string
+    {
+        return 'Purging webhook responses';
+    }
+}

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -107,10 +107,17 @@ class Install extends Migration
     protected function createIndexes()
     {
         $this->createIndex(
-            $this->db->getIndexName(),
+            null,
             '{{%shopifyproducts}}',
             'shopifyId',
             true
+        );
+
+        $this->createIndex(
+            null,
+            '{{%shopifywebhooks}}',
+            'dateCreated',
+            false
         );
 
         // Additional commands depending on the db driver

--- a/src/migrations/m211109_180401_index_date_fields.php
+++ b/src/migrations/m211109_180401_index_date_fields.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace onedesign\craftshopify\migrations;
+
+use craft\db\Migration;
+
+/**
+ * m211109_180401_index_date_fields migration.
+ */
+class m211109_180401_index_date_fields extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $this->createIndex(
+            null,
+            '{{%shopifywebhooks}}',
+            'dateCreated',
+            false
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        $this->dropIndex(
+            $this->db->getIndexName('{{%shopifywebhooks}}', 'dateCreated', false),
+            '{{%shopifywebhooks}}'
+        );
+    }
+}

--- a/src/services/WebhookService.php
+++ b/src/services/WebhookService.php
@@ -11,9 +11,12 @@ namespace onedesign\craftshopify\services;
 
 
 use craft\base\Component;
+use craft\helpers\Queue;
 use craft\helpers\StringHelper;
+use onedesign\craftshopify\jobs\PurgeWebhookResponses;
 use onedesign\craftshopify\models\WebhookResponse;
 use onedesign\craftshopify\records\WebhookResponseRecord;
+use Throwable;
 
 /**
  * @author    One Design Company
@@ -40,4 +43,16 @@ class WebhookService extends Component
         return $record->save();
     }
 
+    /**
+     * Delete webhook responses older than X days
+     *
+     * @param int $olderThan
+     * @throws Throwable
+     */
+    public function purgeResponses(int $olderThan = 30)
+    {
+        Queue::push(new PurgeWebhookResponses([
+            'olderThan' => $olderThan
+        ]));
+    }
 }

--- a/src/templates/_components/utilities/CraftShopify.twig
+++ b/src/templates/_components/utilities/CraftShopify.twig
@@ -76,3 +76,19 @@
     </div>
   </form>
 </div>
+<hr>
+<div>
+  <form class="utility" method="post">
+    {{ csrfInput() }}
+    {{ actionInput('craft-shopify/webhook/purge') }}
+    {{ hiddenInput('olderThan', '90') }}
+
+    <h2>Purge Webhook Records</h2>
+
+    <div>
+      <button type="submit" class="btn submit">
+        Purge Records
+      </button>
+    </div>
+  </form>
+</div>

--- a/src/templates/_components/utilities/CraftShopify.twig
+++ b/src/templates/_components/utilities/CraftShopify.twig
@@ -81,7 +81,7 @@
   <form class="utility" method="post">
     {{ csrfInput() }}
     {{ actionInput('craft-shopify/webhook/purge') }}
-    {{ hiddenInput('olderThan', '90') }}
+    {{ hiddenInput('olderThan', '30') }}
 
     <h2>Purge Webhook Records</h2>
 


### PR DESCRIPTION
The `shopifywebhooks` table can get very large if you have a lot of things happening. This gives you a few ways to deal with that. The primary way is via cron job intended to run every night. This will purge records older than a number of days you can decide